### PR TITLE
Exit with code 1 after an unhandled exception in a command

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,7 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile 'org.rnorth.duct-tape:duct-tape:1.0.4'
     testCompile 'org.mockito:mockito-core:1.10.19'
+    testCompile 'com.github.stefanbirkner:system-rules:1.16.0'
 }
 
 jar {

--- a/src/main/java/io/apiman/cli/command/AbstractCommand.java
+++ b/src/main/java/io/apiman/cli/command/AbstractCommand.java
@@ -148,6 +148,7 @@ public abstract class AbstractCommand implements Command {
 
             } catch (Exception e) {
                 LOGGER.error("Error in " + getCommandDescription(), e);
+                System.exit(1);
             }
 
         } else {

--- a/src/test/java/io/apiman/cli/ExceptionTest.java
+++ b/src/test/java/io/apiman/cli/ExceptionTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2016 Andrew Haines
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apiman.cli;
+
+import io.apiman.cli.common.IntegrationTest;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.ExpectedSystemExit;
+import org.junit.experimental.categories.Category;
+
+/**
+ * @author Andrew Haines {@literal <andrew@haines.org.nz>}
+ */
+@Category(IntegrationTest.class)
+public class ExceptionTest {
+    private static final String INVALID_URL = "this is not a valid url";
+
+    @Rule
+    public final ExpectedSystemExit exit = ExpectedSystemExit.none();
+
+    @Test
+    public void testExitWithCode1OnException() {
+        exit.expectSystemExitWithStatus(1);
+
+        Cli.main("gateway", "list",
+                "--debug",
+                "--server", INVALID_URL,
+                "--serverUsername", "admin",
+                "--serverPassword", "admin123!");
+    }
+}


### PR DESCRIPTION
This PR modifies the catch-all exception handler in the `AbstractCommand` to exit with code 1 to indicate that the command failed.

I've added a test for this case using the [`ExpectedSystemExit`](http://stefanbirkner.github.io/system-rules/#ExpectedSystemExit) JUnit rule.
