### PR TITLE
Adds the ability to resolve placeholder properties using a file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea/
 build/
 *.iml
+classes

--- a/src/test/java/io/apiman/cli/command/DeclarativeTest.java
+++ b/src/test/java/io/apiman/cli/command/DeclarativeTest.java
@@ -16,6 +16,7 @@
 
 package io.apiman.cli.command;
 
+import com.google.common.collect.Lists;
 import io.apiman.cli.common.BaseTest;
 import io.apiman.cli.common.IntegrationTest;
 import io.apiman.cli.core.common.model.ManagementApiVersion;
@@ -30,6 +31,7 @@ import org.junit.experimental.categories.Category;
 
 import java.nio.file.Paths;
 import java.util.Collections;
+import java.util.List;
 
 /**
  * Tests for {@link ApplyCommand}.
@@ -64,7 +66,7 @@ public class DeclarativeTest extends BaseTest {
     public void testApplyDeclaration_JustPlugins() throws Exception {
         final Declaration declaration = DeclarativeUtil.loadDeclaration(
                 Paths.get(DeclarativeTest.class.getResource("/simple-plugin.yml").toURI()), MappingUtil.YAML_MAPPER,
-                Collections.emptyList());
+                Collections.emptyMap());
 
         command.applyDeclaration(declaration);
     }
@@ -78,8 +80,27 @@ public class DeclarativeTest extends BaseTest {
     public void testApplyDeclaration_Full() throws Exception {
         final Declaration declaration = DeclarativeUtil.loadDeclaration(
                 Paths.get(DeclarativeTest.class.getResource("/simple-no-plugin.yml").toURI()), MappingUtil.YAML_MAPPER,
-                Collections.emptyList());
+                Collections.emptyMap());
 
         command.applyDeclaration(declaration);
+    }
+
+    /**
+     * Expect that the configuration in the declaration can be applied, resolving placeholders passed
+     * from the command line as well as from a properties file.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testApplyDeclaration_WithProperties() throws Exception {
+        final List<String> inlineProperties = Lists.newArrayList(
+                "gw.endpoint=http://example.com"
+        );
+
+        command.setDeclarationFile(Paths.get(DeclarativeTest.class.getResource("/simple-placeholders.yml").toURI()));
+        command.setProperties(inlineProperties);
+        command.setPropertiesFile(Paths.get(DeclarativeTest.class.getResource("/declaration-test.properties").toURI()));
+
+        command.applyDeclaration();
     }
 }

--- a/src/test/java/io/apiman/cli/util/DeclarativeUtilTest.java
+++ b/src/test/java/io/apiman/cli/util/DeclarativeUtilTest.java
@@ -16,15 +16,15 @@
 
 package io.apiman.cli.util;
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableMap;
 import io.apiman.cli.command.DeclarativeTest;
 import io.apiman.cli.core.declarative.model.Declaration;
 import io.apiman.cli.core.declarative.model.DeclarativeGateway;
 import org.junit.Test;
 
 import java.nio.file.Paths;
-import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -45,7 +45,7 @@ public class DeclarativeUtilTest {
     public void testLoadDeclarationJson() throws Exception {
         final Declaration declaration = DeclarativeUtil.loadDeclaration(
                 Paths.get(DeclarativeTest.class.getResource("/simple-full.json").toURI()), MappingUtil.JSON_MAPPER,
-                Collections.emptyList());
+                Collections.emptyMap());
 
         assertLoadedModel(declaration, 1);
     }
@@ -59,7 +59,7 @@ public class DeclarativeUtilTest {
     public void testLoadDeclarationYaml() throws Exception {
         final Declaration declaration = DeclarativeUtil.loadDeclaration(
                 Paths.get(DeclarativeTest.class.getResource("/simple-full.yml").toURI()), MappingUtil.YAML_MAPPER,
-                Collections.emptyList());
+                Collections.emptyMap());
 
         assertLoadedModel(declaration, 1);
     }
@@ -72,10 +72,10 @@ public class DeclarativeUtilTest {
     @Test
     public void testLoadDeclarationPlaceholders() throws Exception {
         // set properties
-        final Collection<String> properties = Lists.newArrayList(
-                "gw.endpoint=http://example.com",
-                "gw.username=myuser",
-                "gw.password=secret"
+        final Map<String, String> properties = ImmutableMap.of(
+                "gw.endpoint", "http://example.com",
+                "gw.username", "myuser",
+                "gw.password", "secret"
         );
 
         final Declaration declaration = DeclarativeUtil.loadDeclaration(
@@ -103,7 +103,7 @@ public class DeclarativeUtilTest {
     public void testLoadDeclarationSharedProperties() throws Exception {
         final Declaration declaration = DeclarativeUtil.loadDeclaration(
                 Paths.get(DeclarativeTest.class.getResource("/shared-properties.yml").toURI()),
-                MappingUtil.YAML_MAPPER, Collections.emptyList());
+                MappingUtil.YAML_MAPPER, Collections.emptyMap());
 
         // assert loaded with resolved placeholders
         assertNotNull(declaration);
@@ -127,7 +127,7 @@ public class DeclarativeUtilTest {
     public void testLoadDeclarationSharedJson() throws Exception {
         final Declaration declaration = DeclarativeUtil.loadDeclaration(
                 Paths.get(DeclarativeTest.class.getResource("/shared-policies.json").toURI()), MappingUtil.JSON_MAPPER,
-                Collections.emptyList());
+                Collections.emptyMap());
 
         assertLoadedModel(declaration, 2);
     }
@@ -141,7 +141,7 @@ public class DeclarativeUtilTest {
     public void testLoadDeclarationSharedYaml() throws Exception {
         final Declaration declaration = DeclarativeUtil.loadDeclaration(
                 Paths.get(DeclarativeTest.class.getResource("/shared-policies.yml").toURI()), MappingUtil.YAML_MAPPER,
-                Collections.emptyList());
+                Collections.emptyMap());
 
         assertLoadedModel(declaration, 2);
     }
@@ -149,7 +149,7 @@ public class DeclarativeUtilTest {
     /**
      * Asserts the contents of the model.
      *
-     * @param declaration the model to assert
+     * @param declaration      the model to assert
      * @param expectedApiCount the number of API items
      */
     private void assertLoadedModel(Declaration declaration, int expectedApiCount) {

--- a/src/test/resources/declaration-test.properties
+++ b/src/test/resources/declaration-test.properties
@@ -1,0 +1,2 @@
+gw.username=user
+gw.password=Pa$$word1!


### PR DESCRIPTION
Fixes #16 

In addition to properties provided to the CLI command directly, it is now possible to specify the path to a properties file containing key-value pairs.

Example:

```
./apiman apply -f <declaration file> --propertiesFile /path/to/placeholder.properties
```
