### PR TITLE
Adds support for multiple versions of an API in the same declaration file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Added
+- Adds support for multiple versions of an API in the same declaration file.
+### Changed
+- Use of 'initialVersion' in declaration files is deprecated and will be removed in future - use 'version' instead.
+
 ## [0.2.2] - 2016-09-20
 ### Added
 - Adds support for XML format Java properties files.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Here's a simple YAML file (you can use JSON if you want):
       apis:
         - name: "example"
           description: "Example API"
-          initialVersion: "1.0"
+          version: "1.0"
           published: true
           config:
             endpoint: "http://example.com"

--- a/examples/declarative/backend-requires-http-auth.json
+++ b/examples/declarative/backend-requires-http-auth.json
@@ -27,7 +27,7 @@
       {
         "name": "example",
         "description": "Example API",
-        "initialVersion": "1.0",
+        "version": "1.0",
         "published": true,
         "config": {
           "endpoint": "http://example.com",

--- a/examples/declarative/backend-requires-http-auth.yml
+++ b/examples/declarative/backend-requires-http-auth.yml
@@ -19,7 +19,7 @@
     apis:
       - name: "example"
         description: "Example API"
-        initialVersion: "1.0"
+        version: "1.0"
         published: true
         config:
           endpoint: "http://example.com"

--- a/examples/declarative/shared-policies.json
+++ b/examples/declarative/shared-policies.json
@@ -38,7 +38,7 @@
       {
         "name": "example1",
         "description": "Example API 1",
-        "initialVersion": "1.0",
+        "version": "1.0",
         "published": true,
         "config": {
           "endpoint": "http://example.com",
@@ -53,7 +53,7 @@
       {
         "name": "example2",
         "description": "Example API 2",
-        "initialVersion": "1.0",
+        "version": "1.0",
         "published": true,
         "config": {
           "endpoint": "http://example.com",

--- a/examples/declarative/shared-policies.yml
+++ b/examples/declarative/shared-policies.yml
@@ -25,7 +25,7 @@
     apis:
       - name: "example1"
         description: "Example API 1"
-        initialVersion: "1.0"
+        version: "1.0"
         published: true
         config:
           endpoint: "http://example.com"
@@ -36,7 +36,7 @@
           - "sharedPolicy"
       - name: "example2"
         description: "Example API 2"
-        initialVersion: "1.0"
+        version: "1.0"
         published: true
         config:
           endpoint: "http://example.com"

--- a/examples/declarative/shared-properties.yml
+++ b/examples/declarative/shared-properties.yml
@@ -18,7 +18,7 @@
     apis:
       - name: "example1"
         description: "Example API 1"
-        initialVersion: "1.0"
+        version: "1.0"
         published: true
         config:
           endpoint: "${commonApiEndpoint}"
@@ -27,7 +27,7 @@
           gateway: "test-gw"
       - name: "example2"
         description: "Example API 2"
-        initialVersion: "1.0"
+        version: "1.0"
         published: true
         config:
           endpoint: "${commonApiEndpoint}"

--- a/examples/declarative/simple.json
+++ b/examples/declarative/simple.json
@@ -27,7 +27,7 @@
       {
         "name": "example",
         "description": "Example API",
-        "initialVersion": "1.0",
+        "version": "1.0",
         "published": true,
         "config": {
           "endpoint": "http://example.com",

--- a/examples/declarative/simple.yml
+++ b/examples/declarative/simple.yml
@@ -19,7 +19,7 @@
     apis:
       - name: "example"
         description: "Example API"
-        initialVersion: "1.0"
+        version: "1.0"
         published: true
         config:
           endpoint: "http://example.com"

--- a/src/main/java/io/apiman/cli/core/api/Version11xServerApi.java
+++ b/src/main/java/io/apiman/cli/core/api/Version11xServerApi.java
@@ -18,6 +18,7 @@ package io.apiman.cli.core.api;
 
 import io.apiman.cli.core.api.model.Api;
 import io.apiman.cli.core.api.model.ApiPolicy;
+import io.apiman.cli.core.api.model.ApiVersion;
 import io.apiman.cli.core.api.model.ServiceConfig;
 import retrofit.client.Response;
 import retrofit.http.*;
@@ -33,11 +34,17 @@ public interface Version11xServerApi {
     @POST("/organizations/{orgName}/services")
     Response create(@Path("orgName") String orgName, @Body Api api);
 
+    @POST("/organizations/{orgName}/services/{serviceName}/versions")
+    Response createVersion(@Path("orgName") String orgName, @Path("serviceName") String serviceName, @Body ApiVersion apiVersion);
+
     @GET("/organizations/{orgName}/services")
     List<Api> list(@Path("orgName") String orgName);
 
+    @GET("/organizations/{orgName}/services/{serviceName}")
+    Api fetch(@Path("orgName") String orgName, @Path("serviceName") String serviceName);
+
     @GET("/organizations/{orgName}/services/{serviceName}/versions/{version}")
-    Api fetch(@Path("orgName") String orgName, @Path("serviceName") String serviceName, @Path("version") String version);
+    Api fetchVersion(@Path("orgName") String orgName, @Path("serviceName") String serviceName, @Path("version") String version);
 
     @PUT("/organizations/{orgName}/services/{serviceName}/versions/{version}")
     Response configure(@Path("orgName") String orgName, @Path("serviceName") String serviceName,

--- a/src/main/java/io/apiman/cli/core/api/Version12xServerApi.java
+++ b/src/main/java/io/apiman/cli/core/api/Version12xServerApi.java
@@ -19,6 +19,7 @@ package io.apiman.cli.core.api;
 import io.apiman.cli.core.api.model.Api;
 import io.apiman.cli.core.api.model.ApiConfig;
 import io.apiman.cli.core.api.model.ApiPolicy;
+import io.apiman.cli.core.api.model.ApiVersion;
 import retrofit.client.Response;
 import retrofit.http.*;
 
@@ -33,11 +34,17 @@ public interface Version12xServerApi {
     @POST("/organizations/{orgName}/apis")
     Response create(@Path("orgName") String orgName, @Body Api api);
 
+    @POST("/organizations/{orgName}/apis/{apiName}/versions")
+    Response createVersion(@Path("orgName") String orgName, @Path("apiName") String apiName, @Body ApiVersion apiVersion);
+
     @GET("/organizations/{orgName}/apis")
     List<Api> list(@Path("orgName") String orgName);
 
+    @GET("/organizations/{orgName}/apis/{apiName}")
+    Api fetch(@Path("orgName") String orgName, @Path("apiName") String apiName);
+
     @GET("/organizations/{orgName}/apis/{apiName}/versions/{version}")
-    Api fetch(@Path("orgName") String orgName, @Path("apiName") String apiName, @Path("version") String version);
+    Api fetchVersion(@Path("orgName") String orgName, @Path("apiName") String apiName, @Path("version") String version);
 
     @PUT("/organizations/{orgName}/apis/{apiName}/versions/{version}")
     Response configure(@Path("orgName") String orgName, @Path("apiName") String apiName,

--- a/src/main/java/io/apiman/cli/core/api/VersionAgnosticApi.java
+++ b/src/main/java/io/apiman/cli/core/api/VersionAgnosticApi.java
@@ -19,6 +19,7 @@ package io.apiman.cli.core.api;
 import io.apiman.cli.core.api.model.Api;
 import io.apiman.cli.core.api.model.ApiConfig;
 import io.apiman.cli.core.api.model.ApiPolicy;
+import io.apiman.cli.core.api.model.ApiVersion;
 import retrofit.client.Response;
 
 import java.util.List;
@@ -29,9 +30,13 @@ import java.util.List;
 public interface VersionAgnosticApi {
     Response create(String orgName, Api api);
 
+    Response createVersion(String orgName, String apiName, ApiVersion apiVersion);
+
     List<Api> list(String orgName);
 
-    Api fetch(String orgName, String apiName, String version);
+    Api fetch(String orgName, String apiName);
+
+    Api fetchVersion(String orgName, String apiName, String version);
 
     Response configure(String orgName, String apiName,
                        String version, ApiConfig config);

--- a/src/main/java/io/apiman/cli/core/api/factory/Version11XManagementApiFactoryImpl.java
+++ b/src/main/java/io/apiman/cli/core/api/factory/Version11XManagementApiFactoryImpl.java
@@ -18,10 +18,7 @@ package io.apiman.cli.core.api.factory;
 
 import io.apiman.cli.core.api.Version11xServerApi;
 import io.apiman.cli.core.api.VersionAgnosticApi;
-import io.apiman.cli.core.api.model.Api;
-import io.apiman.cli.core.api.model.ApiConfig;
-import io.apiman.cli.core.api.model.ApiPolicy;
-import io.apiman.cli.core.api.model.ServiceConfig;
+import io.apiman.cli.core.api.model.*;
 import io.apiman.cli.management.factory.AbstractManagementApiFactory;
 import io.apiman.cli.management.factory.ManagementApiFactory;
 import retrofit.client.Response;
@@ -47,13 +44,23 @@ public class Version11XManagementApiFactoryImpl extends AbstractManagementApiFac
             }
 
             @Override
+            public Response createVersion(String orgName, String apiName, ApiVersion apiVersion) {
+                return delegate.createVersion(orgName, apiName, apiVersion);
+            }
+
+            @Override
             public List<Api> list(String orgName) {
                 return delegate.list(orgName);
             }
 
             @Override
-            public Api fetch(String orgName, String apiName, String version) {
-                return delegate.fetch(orgName, apiName, version);
+            public Api fetch(String orgName, String apiName) {
+                return delegate.fetch(orgName, apiName);
+            }
+
+            @Override
+            public Api fetchVersion(String orgName, String apiName, String version) {
+                return delegate.fetchVersion(orgName, apiName, version);
             }
 
             @Override

--- a/src/main/java/io/apiman/cli/core/api/factory/Version12XManagementApiFactoryImpl.java
+++ b/src/main/java/io/apiman/cli/core/api/factory/Version12XManagementApiFactoryImpl.java
@@ -21,6 +21,7 @@ import io.apiman.cli.core.api.VersionAgnosticApi;
 import io.apiman.cli.core.api.model.Api;
 import io.apiman.cli.core.api.model.ApiConfig;
 import io.apiman.cli.core.api.model.ApiPolicy;
+import io.apiman.cli.core.api.model.ApiVersion;
 import io.apiman.cli.management.factory.AbstractManagementApiFactory;
 import io.apiman.cli.management.factory.ManagementApiFactory;
 import retrofit.client.Response;
@@ -44,13 +45,23 @@ public class Version12XManagementApiFactoryImpl extends AbstractManagementApiFac
             }
 
             @Override
+            public Response createVersion(String orgName, String apiName, ApiVersion apiVersion) {
+                return delegate.createVersion(orgName, apiName, apiVersion);
+            }
+
+            @Override
             public List<Api> list(String orgName) {
                 return delegate.list(orgName);
             }
 
             @Override
-            public Api fetch(String orgName, String apiName, String version) {
-                return delegate.fetch(orgName, apiName, version);
+            public Api fetch(String orgName, String apiName) {
+                return delegate.fetch(orgName, apiName);
+            }
+
+            @Override
+            public Api fetchVersion(String orgName, String apiName, String version) {
+                return delegate.fetchVersion(orgName, apiName, version);
             }
 
             @Override

--- a/src/main/java/io/apiman/cli/core/api/model/Api.java
+++ b/src/main/java/io/apiman/cli/core/api/model/Api.java
@@ -37,6 +37,9 @@ public class Api {
     @JsonProperty
     private String organizationName;
 
+    /**
+     * Note: use {@link #version} instead for declarative API configuration.
+     */
     @JsonProperty
     private String initialVersion;
 
@@ -59,8 +62,20 @@ public class Api {
         return name;
     }
 
+    public void setInitialVersion(String initialVersion) {
+        this.initialVersion = initialVersion;
+    }
+
     public String getInitialVersion() {
         return initialVersion;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public String getVersion() {
+        return version;
     }
 
     public String getStatus() {

--- a/src/main/java/io/apiman/cli/core/api/model/ApiVersion.java
+++ b/src/main/java/io/apiman/cli/core/api/model/ApiVersion.java
@@ -1,0 +1,27 @@
+package io.apiman.cli.core.api.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Models an API version.
+ *
+ * @author Pete Cornish {@literal <outofcoffee@gmail.com>}
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ApiVersion {
+    @JsonProperty
+    private String version;
+
+    /**
+     * Never clone a previous version when creating a new version.
+     */
+    @JsonProperty
+    final private boolean clone = false;
+
+    public ApiVersion(String version) {
+        this.version = version;
+    }
+}

--- a/src/test/java/io/apiman/cli/command/DeclarativeTest.java
+++ b/src/test/java/io/apiman/cli/command/DeclarativeTest.java
@@ -21,16 +21,12 @@ import io.apiman.cli.common.BaseTest;
 import io.apiman.cli.common.IntegrationTest;
 import io.apiman.cli.core.common.model.ManagementApiVersion;
 import io.apiman.cli.core.declarative.command.ApplyCommand;
-import io.apiman.cli.core.declarative.model.Declaration;
-import io.apiman.cli.util.DeclarativeUtil;
 import io.apiman.cli.util.LogUtil;
-import io.apiman.cli.util.MappingUtil;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import java.nio.file.Paths;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -64,11 +60,8 @@ public class DeclarativeTest extends BaseTest {
      */
     @Test
     public void testApplyDeclaration_JustPlugins() throws Exception {
-        final Declaration declaration = DeclarativeUtil.loadDeclaration(
-                Paths.get(DeclarativeTest.class.getResource("/simple-plugin.yml").toURI()), MappingUtil.YAML_MAPPER,
-                Collections.emptyMap());
-
-        command.applyDeclaration(declaration);
+        command.setDeclarationFile(Paths.get(DeclarativeTest.class.getResource("/simple-plugin.yml").toURI()));
+        command.applyDeclaration();
     }
 
     /**
@@ -78,11 +71,8 @@ public class DeclarativeTest extends BaseTest {
      */
     @Test
     public void testApplyDeclaration_Full() throws Exception {
-        final Declaration declaration = DeclarativeUtil.loadDeclaration(
-                Paths.get(DeclarativeTest.class.getResource("/simple-no-plugin.yml").toURI()), MappingUtil.YAML_MAPPER,
-                Collections.emptyMap());
-
-        command.applyDeclaration(declaration);
+        command.setDeclarationFile(Paths.get(DeclarativeTest.class.getResource("/simple-no-plugin.yml").toURI()));
+        command.applyDeclaration();
     }
 
     /**
@@ -108,7 +98,18 @@ public class DeclarativeTest extends BaseTest {
                 Paths.get(DeclarativeTest.class.getResource("/placeholder-test.properties").toURI()),
                 Paths.get(DeclarativeTest.class.getResource("/placeholder-test.xml").toURI())
         ));
+        command.applyDeclaration();
+    }
 
+    /**
+     * Expect that the configuration in the declaration can be applied, when there is more than one version
+     * of a single API in the same file.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testApplyDeclaration_MultipleVersions() throws Exception {
+        command.setDeclarationFile(Paths.get(DeclarativeTest.class.getResource("/multiple-versions.yml").toURI()));
         command.applyDeclaration();
     }
 }

--- a/src/test/resources/multiple-versions.yml
+++ b/src/test/resources/multiple-versions.yml
@@ -1,4 +1,4 @@
-# Simple apiman example
+# Simple apiman example, without adding a plugin
 ---
   system:
     gateways:
@@ -9,25 +9,30 @@
           endpoint: "http://localhost:8080/apiman-gateway-api"
           username: "apimanager"
           password: "apiman123!"
-    plugins:
-      - groupId: "io.apiman.plugins"
-        artifactId: "apiman-plugins-test-policy"
-        version: "1.2.4.Final"
   org:
     name: "test"
     description: "Test organisation"
     apis:
-      - name: "example"
-        description: "Example API"
+      - name: "multi-version-example"
+        description: "Multi-version example API V1"
         version: "1.0"
         published: true
         config:
-          endpoint: "http://example.com"
+          endpoint: "http://example.com/v1"
           endpointType: "rest"
-          security:
-            authorizationType: "basic"
-            username: "user"
-            password: "Password123"
+          public: true
+          gateway: "test-gw"
+        policies:
+          - name: "CachingPolicy"
+            config:
+              ttl: 60
+      - name: "multi-version-example"
+        description: "Multi-version example API V2"
+        version: "2.0"
+        published: true
+        config:
+          endpoint: "http://example.com/v2"
+          endpointType: "rest"
           public: true
           gateway: "test-gw"
         policies:

--- a/src/test/resources/shared-policies.json
+++ b/src/test/resources/shared-policies.json
@@ -38,7 +38,7 @@
       {
         "name": "example1",
         "description": "Example API 1",
-        "initialVersion": "1.0",
+        "version": "1.0",
         "published": true,
         "config": {
           "endpoint": "http://example.com",
@@ -58,7 +58,7 @@
       {
         "name": "example2",
         "description": "Example API 2",
-        "initialVersion": "1.0",
+        "version": "1.0",
         "published": true,
         "config": {
           "endpoint": "http://example.com",

--- a/src/test/resources/shared-policies.yml
+++ b/src/test/resources/shared-policies.yml
@@ -25,7 +25,7 @@
     apis:
       - name: "example1"
         description: "Example API 1"
-        initialVersion: "1.0"
+        version: "1.0"
         published: true
         config:
           endpoint: "http://example.com"
@@ -40,7 +40,7 @@
           - "sharedPolicy"
       - name: "example2"
         description: "Example API 2"
-        initialVersion: "1.0"
+        version: "1.0"
         published: true
         config:
           endpoint: "http://example.com"

--- a/src/test/resources/simple-full.json
+++ b/src/test/resources/simple-full.json
@@ -27,7 +27,7 @@
       {
         "name": "example",
         "description": "Example API",
-        "initialVersion": "1.0",
+        "version": "1.0",
         "published": true,
         "config": {
           "endpoint": "http://example.com",

--- a/src/test/resources/simple-no-plugin.yml
+++ b/src/test/resources/simple-no-plugin.yml
@@ -15,7 +15,7 @@
     apis:
       - name: "example"
         description: "Example API"
-        initialVersion: "1.0"
+        version: "1.0"
         published: true
         config:
           endpoint: "http://example.com"


### PR DESCRIPTION
It is currently not possible to define multiple versions of an API in a single file.

This PR adds support for this, so we can do things like:

```
# Multiple versions of an API defined in a single file.

---
  system:
    gateways:
      - name: "test-gw"
        description: "Test Gateway"
        type: "REST"
        config:
          endpoint: "http://localhost:8080/apiman-gateway-api"
          username: "apimanager"
          password: "apiman123!"
  org:
    name: "test"
    description: "Test organisation"
    apis:
      - name: "multi-version-example"
        description: "Multi-version example API V1"
        version: "1.0"
        published: true
        config:
          endpoint: "http://example.com/v1"
          endpointType: "rest"
          public: true
          gateway: "test-gw"
        policies:
          - name: "CachingPolicy"
            config:
              ttl: 60
      - name: "multi-version-example"
        description: "Multi-version example API V2"
        version: "2.0"
        published: true
        config:
          endpoint: "http://example.com/v2"
          endpointType: "rest"
          public: true
          gateway: "test-gw"
        policies:
          - name: "CachingPolicy"
            config:
              ttl: 60
```
