### PR TITLE
Support for multiple gateways and plans with declarative command

### DIFF
--- a/src/main/java/io/apiman/cli/core/api/command/ApiCreateCommand.java
+++ b/src/main/java/io/apiman/cli/core/api/command/ApiCreateCommand.java
@@ -30,6 +30,8 @@ import org.kohsuke.args4j.CmdLineParser;
 import org.kohsuke.args4j.Option;
 
 import java.text.MessageFormat;
+import java.util.List;
+import java.util.StringTokenizer;
 
 /**
  * Create an API.
@@ -60,6 +62,9 @@ public class ApiCreateCommand extends AbstractApiCommand implements ApiMixin {
     @Option(name = "--gateway", aliases = {"-g"}, usage = "Gateway")
     private String gateway = "TheGateway";
 
+    @Option(name = "--gateways", aliases = {"-gs"}, usage = "Gateways")
+    private String gateways = "";
+
     @Override
     protected String getCommandDescription() {
         return MessageFormat.format("Create {0}", getModelName());
@@ -74,12 +79,22 @@ public class ApiCreateCommand extends AbstractApiCommand implements ApiMixin {
                 description,
                 initialVersion);
 
+        final List gatewaysList = Lists.newArrayList();
+        if (!gateways.equals("")) {
+            final StringTokenizer st = new StringTokenizer(gateways);
+            while (st.hasMoreTokens()) {
+                gatewaysList.add(new ApiGateway(st.nextToken()));
+            }
+        } else {
+            gatewaysList.add(new ApiGateway(gateway));
+        }
+        
         final ApiConfig config = new ApiConfig(
                 endpoint,
                 endpointType,
                 publicApi,
-                Lists.newArrayList(new ApiGateway(gateway)));
-
+                gatewaysList);
+        
         // create
         final VersionAgnosticApi apiClient = buildServerApiClient(VersionAgnosticApi.class, serverVersion);
         ManagementApiUtil.invokeAndCheckResponse(() -> apiClient.create(orgName, api));

--- a/src/main/java/io/apiman/cli/core/declarative/model/DeclarativeOrg.java
+++ b/src/main/java/io/apiman/cli/core/declarative/model/DeclarativeOrg.java
@@ -34,11 +34,22 @@ public class DeclarativeOrg extends Org {
     @JsonProperty
     private List<DeclarativeApi> apis;
 
+    @JsonProperty
+    private List<DeclarativePlan> plans;
+
     public List<DeclarativeApi> getApis() {
         return apis;
     }
 
     public void setApis(List<DeclarativeApi> apis) {
         this.apis = apis;
+    }
+
+    public List<DeclarativePlan> getPlans() {
+        return plans;
+    }
+
+    public void setPlans(List<DeclarativePlan> plans) {
+        this.plans = plans;
     }
 }

--- a/src/main/java/io/apiman/cli/core/declarative/model/DeclarativePlan.java
+++ b/src/main/java/io/apiman/cli/core/declarative/model/DeclarativePlan.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016 Pete Cornish
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apiman.cli.core.declarative.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.apiman.cli.core.plan.model.Plan;
+
+import java.util.List;
+
+/**
+ * Declarative Plan representation.
+ *
+ * @author Jean-Charles Quantin {@literal <jeancharles.quantin@gmail.com>}
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class DeclarativePlan extends Plan {
+
+    @JsonProperty
+    private List<DeclarativePolicy> policies;
+
+    public List<DeclarativePolicy> getPolicies() {
+        return policies;
+    }
+
+    public void setPolicies(List<DeclarativePolicy> policies) {
+        this.policies = policies;
+    }
+
+}

--- a/src/main/java/io/apiman/cli/core/plan/PlanApi.java
+++ b/src/main/java/io/apiman/cli/core/plan/PlanApi.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2016 Pete Cornish
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apiman.cli.core.plan;
+
+import io.apiman.cli.core.api.model.ApiPolicy;
+import io.apiman.cli.core.plan.model.Plan;
+import io.apiman.cli.core.plan.model.PlanVersion;
+import retrofit.client.Response;
+import retrofit.http.*;
+
+import java.util.List;
+
+/**
+ * @author Jean-Charles Quantin {@literal <jeancharles.quantin@gmail.com>}
+ */
+public interface PlanApi {
+    @POST("/organizations/{orgName}/plans")
+    Response create(@Path("orgName") String orgName, @Body Plan plan);
+
+    @POST("/organizations/{orgName}/plans/{planName}/versions")
+    Response createVersion(@Path("orgName") String orgName, @Path("planName") String planName, @Body PlanVersion apiVersion);
+
+    @GET("/organizations/{orgName}/plans")
+    List<Plan> list(@Path("orgName") String orgName);
+
+    @GET("/organizations/{orgName}/plans/{planName}")
+    Plan fetch(@Path("orgName") String orgName, @Path("planName") String planName);
+
+    @GET("/organizations/{orgName}/plans/{planName}/versions/{version}")
+    Plan fetchVersion(@Path("orgName") String orgName, @Path("planName") String planName, @Path("version") String version);
+
+    @POST("/organizations/{orgName}/plans/{planName}/versions/{version}/policies")
+    Response addPolicy(@Path("orgName") String orgName, @Path("planName") String apiName,
+                       @Path("version") String version, @Body ApiPolicy policyConfig);
+
+    @GET("/organizations/{orgName}/plans/{apiName}/versions/{version}/policies")
+    List<ApiPolicy> fetchPolicies(@Path("orgName") String orgName, @Path("apiName") String apiName,
+                                  @Path("version") String version);
+
+    @PUT("/organizations/{orgName}/plans/{planName}/versions/{version}/policies/{policyId}")
+    Response configurePolicy(@Path("orgName") String orgName, @Path("planName") String planName,
+                             @Path("version") String version, @Path("policyId") Long policyId, @Body ApiPolicy policyConfig);
+}

--- a/src/main/java/io/apiman/cli/core/plan/model/Plan.java
+++ b/src/main/java/io/apiman/cli/core/plan/model/Plan.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2016 Pete Cornish
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apiman.cli.core.plan.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Models a Plan.
+ *
+ * @author Jean-Charles Quantin {@literal <jeancharles.quantin@gmail.com>}
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Plan {
+    @JsonProperty
+    private String name;
+
+    @JsonProperty
+    private String description;
+
+    @JsonProperty
+    private String organizationName;
+
+    /**
+     * Note: use {@link #version} instead for declarative API configuration.
+     */
+    @JsonProperty
+    private String initialVersion;
+
+    @JsonProperty
+    private String version;
+
+    @JsonProperty
+    private String status;
+
+    public Plan() {
+    }
+
+    public Plan(String name, String description, String initialVersion) {
+        this.name = name;
+        this.description = description;
+        this.initialVersion = initialVersion;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setInitialVersion(String initialVersion) {
+        this.initialVersion = initialVersion;
+    }
+
+    public String getInitialVersion() {
+        return initialVersion;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+}

--- a/src/main/java/io/apiman/cli/core/plan/model/PlanVersion.java
+++ b/src/main/java/io/apiman/cli/core/plan/model/PlanVersion.java
@@ -1,0 +1,27 @@
+package io.apiman.cli.core.plan.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Models an Plan version.
+ *
+ * @author Jean-Charles Quantin {@literal <jeancharles.quantin@gmail.com>}
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PlanVersion {
+    @JsonProperty
+    private String version;
+
+    /**
+     * Never clone a previous version when creating a new version.
+     */
+    @JsonProperty
+    final private boolean clone = false;
+
+    public PlanVersion(String version) {
+        this.version = version;
+    }
+}

--- a/src/main/java/io/apiman/cli/management/ManagementApiFactoryModule.java
+++ b/src/main/java/io/apiman/cli/management/ManagementApiFactoryModule.java
@@ -25,6 +25,7 @@ import io.apiman.cli.core.common.ActionApi;
 import io.apiman.cli.core.common.model.ManagementApiVersion;
 import io.apiman.cli.core.gateway.GatewayApi;
 import io.apiman.cli.core.org.OrgApi;
+import io.apiman.cli.core.plan.PlanApi;
 import io.apiman.cli.core.plugin.PluginApi;
 import io.apiman.cli.management.binding.ManagementApiBindings;
 import io.apiman.cli.management.factory.ManagementApiFactory;
@@ -61,5 +62,9 @@ public class ManagementApiFactoryModule extends AbstractModule {
         bind(ManagementApiFactory.class)
                 .annotatedWith(ManagementApiBindings.boundTo(VersionAgnosticApi.class, ManagementApiVersion.v12x))
                 .to(Version12XManagementApiFactoryImpl.class).in(Singleton.class);
+
+        bind(ManagementApiFactory.class)
+                .annotatedWith(ManagementApiBindings.boundTo(PlanApi.class))
+                .toInstance(new SimpleManagementApiFactoryImpl<>(PlanApi.class));
     }
 }


### PR DESCRIPTION
Hi,

This is 2 things 
- a small modification of the api command to use more than one gateway to create an API.
I only add a new param "gateways" (with a s) and let the old one "gateway" (without s) to be sure to not break things. I can merge the 2 params together (the one without s) if its preferable.
- the support for plans on the declaratives command. Works with a "plans" section on the root of organisation and with the sames policies declarations than apis inside.

thanks