### PR TITLE
Adds support for applying multiple API declarations at once.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
-- ...
+- Adds support for applying multiple API declarations at once.
 
 ## [0.3.0] - 2018-03-08
 ### Added

--- a/README.md
+++ b/README.md
@@ -282,6 +282,9 @@ Typically, you will administer the Manager, then publish your changes to the Gat
 
 ### Apply declaration
 
+A 'declaration' is a configuration file specifying Gateways, APIs and policies. See the _Declarative API management_
+section for more information.
+
     apiman manager apply [args...]
     
      --declarationFile (-f) PATH : Declaration file
@@ -301,20 +304,27 @@ The following commands are available, when administering the Gateway directly:
     --debug: Log at DEBUG level
     --help, -h: Display usage only
 
+## Tips and tricks
+
+When working with declaration files, in any of the following scenarios:
+
+* declarative gateway
+* declarative manager
+* generate headless gateway configuration 
+
+...the commands support repetition of the `--declarationFile` argument.
+
+This means you can do things like:
+
+    ./apiman manager apply --declarationFile=/path/to/file1.yml --declarationFile=/path/to/file2.yml
+
+...and the declarations will be merged in the order the files are provided.
+
 # Recent changes and Roadmap
 
 For recent changes see the [Changelog](CHANGELOG.md).
 
-## Roadmap
-
-* Support reading management API configuration from environment variables
-* Better support for non-public APIs
-* Support deletion
-* Support for retiring published APIs
-* Option to skip or fail for existing items in declarative mode
-* Docs - split examples into separate file
-* Docs - split detailed API usage into separate file
-* Docs - simplify README examples
+See the [Roadmap](ROADMAP.md) document for future plans. 
 
 # Building
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,13 @@
+Roadmap
+=======
+
+* Support reading management API configuration from environment variables
+* Better support for non-public APIs
+* Support deletion
+* Support for retiring published APIs
+* Option to skip or fail for existing items in declarative mode
+* Docs - split examples into separate file
+* Docs - split detailed API usage into separate file
+* Docs - simplify README examples
+
+If you have other suggestions, please raise an issue!

--- a/src/main/java/io/apiman/cli/command/core/AbstractCommand.java
+++ b/src/main/java/io/apiman/cli/command/core/AbstractCommand.java
@@ -20,6 +20,7 @@ import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterDescription;
 import com.beust.jcommander.ParameterException;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.inject.Injector;
 import io.apiman.cli.exception.CommandException;
@@ -59,7 +60,7 @@ public abstract class AbstractCommand implements Command {
      * land into it, throwing a custom error message instead.
      */
     @Parameter(hidden=true)
-    private List<String> mainParameter = new ArrayList<>();
+    private List<String> mainParameter = Lists.newArrayList();
 
     /**
      * The parent Command (<code>null</code> if root).

--- a/src/main/java/io/apiman/cli/command/declarative/DeclarativeUtil.java
+++ b/src/main/java/io/apiman/cli/command/declarative/DeclarativeUtil.java
@@ -76,7 +76,7 @@ public class DeclarativeUtil {
             return declaration;
 
         } catch (IOException e) {
-            throw new DeclarativeException(e);
+            throw new DeclarativeException("Unable to load declaration: " + path, e);
         }
     }
 
@@ -90,7 +90,7 @@ public class DeclarativeUtil {
      * @throws IOException
      */
     private static BaseDeclaration loadDeclaration(ObjectMapper mapper, String unresolved,
-                                               Map<String, String> properties) throws IOException {
+                                                   Map<String, String> properties) throws IOException {
 
         final String resolved = BeanUtil.resolvePlaceholders(unresolved, properties);
         LOGGER.trace("Declaration file after resolving {} placeholders: {}", properties.size(), resolved);

--- a/src/main/java/io/apiman/cli/gatewayapi/declarative/command/GatewayApplyCommand.java
+++ b/src/main/java/io/apiman/cli/gatewayapi/declarative/command/GatewayApplyCommand.java
@@ -57,12 +57,14 @@ public class GatewayApplyCommand extends AbstractApplyCommand
     }
 
     @Override
-    protected void applyDeclaration(BaseDeclaration declaration) {
-        GatewayApiDataModel dataModel = new GatewayApiDataModel(declaration, policyResolver);
-        // Do gateway status checks: Tests whether gateways exist and advertise as up/available.
-        doGatewayStatusChecks(dataModel);
-        // Finally, publish.
-        publishAll(dataModel);
+    protected void applyDeclarations(List<BaseDeclaration> declarations) {
+        declarations.forEach(declaration -> {
+            GatewayApiDataModel dataModel = new GatewayApiDataModel(declaration, policyResolver);
+            // Do gateway status checks: Tests whether gateways exist and advertise as up/available.
+            doGatewayStatusChecks(dataModel);
+            // Finally, publish.
+            publishAll(dataModel);
+        });
     }
 
     private void doGatewayStatusChecks(GatewayApiDataModel dataModel) {

--- a/src/main/java/io/apiman/cli/gatewayapi/model/GatewayApiDataModel.java
+++ b/src/main/java/io/apiman/cli/gatewayapi/model/GatewayApiDataModel.java
@@ -15,6 +15,7 @@
  */
 package io.apiman.cli.gatewayapi.model;
 
+import com.google.common.collect.Lists;
 import io.apiman.cli.command.api.model.ApiGateway;
 import io.apiman.cli.command.api.model.EndpointProperties;
 import io.apiman.cli.command.declarative.model.BaseDeclaration;
@@ -35,7 +36,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.AbstractMap;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -115,7 +115,7 @@ public class GatewayApiDataModel {
             Api addApi = entry.getKey();
             List<DeclarativeGateway> gateways = entry.getValue();
             for (DeclarativeGateway gateway : gateways) {
-                List<Api> apiList = outMap.getOrDefault(gateway, new ArrayList<>());
+                List<Api> apiList = outMap.getOrDefault(gateway, Lists.newArrayList());
                 apiList.add(addApi);
                 outMap.put(gateway, apiList);
             }

--- a/src/main/java/io/apiman/cli/managerapi/declarative/command/ManagerApplyCommand.java
+++ b/src/main/java/io/apiman/cli/managerapi/declarative/command/ManagerApplyCommand.java
@@ -31,6 +31,8 @@ import org.apache.logging.log4j.Logger;
 
 import javax.inject.Inject;
 
+import java.util.List;
+
 import static java.util.Optional.ofNullable;
 
 @Parameters(commandDescription = "Apply Apiman Manager declaration")
@@ -58,27 +60,29 @@ public class ManagerApplyCommand extends AbstractApplyCommand {
     /**
      * Apply the given Declaration.
      *
-     * @param declaration the Declaration to apply.
+     * @param declarations the Declarations to apply.
      */
     @Override
-    protected void applyDeclaration(BaseDeclaration declaration) {
-        LOGGER.debug("Applying declaration");
+    protected void applyDeclarations(List<BaseDeclaration> declarations) {
+        declarations.forEach(declaration -> {
+            LOGGER.debug("Applying declaration");
 
-        // add gateways
-        ofNullable(declaration.getSystem().getGateways()).ifPresent(declarativeService::applyGateways);
+            // add gateways
+            ofNullable(declaration.getSystem().getGateways()).ifPresent(declarativeService::applyGateways);
 
-        // add plugins
-        ofNullable(declaration.getSystem().getPlugins()).ifPresent(pluginService::addPlugins);
+            // add plugins
+            ofNullable(declaration.getSystem().getPlugins()).ifPresent(pluginService::addPlugins);
 
-        // add org and APIs
-        ofNullable(declaration.getOrg()).ifPresent(org -> {
-            declarativeService.applyOrg(org);
+            // add org and APIs
+            ofNullable(declaration.getOrg()).ifPresent(org -> {
+                declarativeService.applyOrg(org);
 
-            ofNullable(org.getApis()).ifPresent(apis ->
-                    declarativeService.applyApis(serverVersion, apis, org.getName()));
+                ofNullable(org.getApis()).ifPresent(apis ->
+                        declarativeService.applyApis(serverVersion, apis, org.getName()));
+            });
+
+            LOGGER.info("Applied declaration");
         });
-
-        LOGGER.info("Applied declaration");
     }
 
     public void setServerAddress(String serverAddress) {

--- a/src/main/java/io/apiman/cli/util/PolicyResolver.java
+++ b/src/main/java/io/apiman/cli/util/PolicyResolver.java
@@ -16,6 +16,7 @@
 
 package io.apiman.cli.util;
 
+import com.google.common.collect.Lists;
 import com.google.common.io.Files;
 import com.google.common.io.Resources;
 import io.apiman.cli.exception.CommandException;
@@ -28,7 +29,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.net.URL;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -55,7 +55,7 @@ public final class PolicyResolver extends AbstractPluginRegistry {
     private void buildInbuiltPolicyMap() {
         URL policyDefResource = Resources.getResource("data/all-policyDefs.json");
         @SuppressWarnings("unchecked")
-        List<PolicyDefinitionBean> inbuilts = new ArrayList<>(MappingUtil.readJsonValue(policyDefResource, List.class, PolicyDefinitionBean.class));
+        List<PolicyDefinitionBean> inbuilts = Lists.newArrayList(MappingUtil.readJsonValue(policyDefResource, List.class, PolicyDefinitionBean.class));
 
         for (PolicyDefinitionBean policyDef : inbuilts) {
             inbuiltPolicyMap.put(policyDef.getId().toLowerCase(), policyDef); // TODO

--- a/src/test/java/io/apiman/cli/command/GatewayDeclarativeTest.java
+++ b/src/test/java/io/apiman/cli/command/GatewayDeclarativeTest.java
@@ -63,10 +63,10 @@ public class GatewayDeclarativeTest extends BaseTest {
 
     @Test
     public void testApplyDeclaration_PluginAndBuiltInPolicies() throws Exception {
-        command.setDeclarationFile(getResourceAsPath("/gateway/plugin-and-builtin-policies.yml"));
+        command.setDeclarationFiles(getResourceAsPathList("/gateway/plugin-and-builtin-policies.yml"));
         Api expected = expectJson("/gateway/plugin-and-builtin-policies-expectation.json", Api.class);
         // Run
-        command.applyDeclaration();
+        command.applyDeclarations();
         // Verify
         verify(mGatewayApi).publishApi(Mockito.argThat(api -> EqualsBuilder.reflectionEquals(api, expected)));
     }
@@ -81,11 +81,11 @@ public class GatewayDeclarativeTest extends BaseTest {
      */
     @Test
     public void testApplyDeclaration_IgnoreUnusedFields() throws Exception {
-        command.setDeclarationFile(getResourceAsPath("/multiple-versions.yml"));
+        command.setDeclarationFiles(getResourceAsPathList("/multiple-versions.yml"));
         Api expected1 = expectJson("/gateway/multiple-versions-expectation-1.json", Api.class);
         Api expected2 = expectJson("/gateway/multiple-versions-expectation-2.json", Api.class);
         // Run
-        command.applyDeclaration();
+        command.applyDeclarations();
         // Verify
         verify(mGatewayApi).publishApi(Mockito.argThat(api -> EqualsBuilder.reflectionEquals(api, expected1)));
         verify(mGatewayApi).publishApi(Mockito.argThat(api -> EqualsBuilder.reflectionEquals(api, expected2)));
@@ -99,11 +99,11 @@ public class GatewayDeclarativeTest extends BaseTest {
      */
     @Test
     public void testApplyDeclaration_SharedPolicies() throws Exception {
-        command.setDeclarationFile(getResourceAsPath("/shared-policies.yml"));
+        command.setDeclarationFiles(getResourceAsPathList("/shared-policies.yml"));
         Api expected1 = expectJson("/gateway/shared-policies-expectation-1.json", Api.class);
         Api expected2 = expectJson("/gateway/shared-policies-expectation-2.json", Api.class);
         // Run
-        command.applyDeclaration();
+        command.applyDeclarations();
         // Verify
         verify(mGatewayApi).publishApi(Mockito.argThat(api -> EqualsBuilder.reflectionEquals(api, expected1)));
         verify(mGatewayApi).publishApi(Mockito.argThat(api -> EqualsBuilder.reflectionEquals(api, expected2)));

--- a/src/test/java/io/apiman/cli/common/BaseTest.java
+++ b/src/test/java/io/apiman/cli/common/BaseTest.java
@@ -17,6 +17,7 @@
 package io.apiman.cli.common;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
 import com.jayway.restassured.RestAssured;
 import com.google.common.io.BaseEncoding;
 import io.apiman.cli.Cli;
@@ -28,11 +29,12 @@ import org.junit.ClassRule;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 
 import static io.apiman.cli.util.Functions.not;
 import static java.util.Optional.ofNullable;
@@ -43,11 +45,6 @@ import static java.util.Optional.ofNullable;
  * @author Pete Cornish {@literal <outofcoffee@gmail.com>}
  */
 public class BaseTest {
-    /**
-     * Basic auth header.
-     */
-    protected static final String HEADER_AUTHORIZATION = "Authorization";
-
     /**
      * Management API username.
      */
@@ -112,18 +109,24 @@ public class BaseTest {
     }
 
     protected <T> T expectJson(String resource, Class<T> klazz) throws URISyntaxException, MalformedURLException {
-        return MappingUtil.readJsonValue(getResourceAsURL(resource), klazz);
+        return MappingUtil.readJsonValue(getResourceAsURI(resource).toURL(), klazz);
     }
 
-    protected URL getResourceAsURL(String resource) throws URISyntaxException, MalformedURLException {
-        return BaseTest.class.getResource(resource).toURI().toURL();
+    protected URI getResourceAsURI(String resource) throws URISyntaxException {
+        return BaseTest.class.getResource(resource).toURI();
     }
 
-    protected Path getResourceAsPath(String resource) throws URISyntaxException, MalformedURLException {
-        return Paths.get(getResourceAsURL(resource).toURI());
+    protected Path getResourceAsPath(String resource) throws URISyntaxException {
+        return Paths.get(getResourceAsURI(resource));
+    }
+
+    protected List<Path> getResourceAsPathList(String resource) throws URISyntaxException {
+        final List<Path> paths = Lists.newArrayList();
+        paths.add(getResourceAsPath(resource));
+        return paths;
     }
 
     protected String getResourceAsString(String resource) throws URISyntaxException, IOException {
-        return new String(Files.readAllBytes(Paths.get(getResourceAsURL(resource).toURI())));
+        return new String(Files.readAllBytes(Paths.get(getResourceAsURI(resource))));
     }
 }

--- a/src/test/java/io/apiman/cli/common/WaitForHttp.java
+++ b/src/test/java/io/apiman/cli/common/WaitForHttp.java
@@ -17,6 +17,7 @@
 package io.apiman.cli.common;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
 import io.apiman.cli.util.AuthUtil;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -31,7 +32,6 @@ import org.rnorth.ducttape.ratelimits.RateLimiterBuilder;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -78,7 +78,7 @@ public class WaitForHttp implements TestRule {
         return new Statement() {
             @Override
             public void evaluate() throws Throwable {
-                final List<Throwable> errors = new ArrayList<>();
+                final List<Throwable> errors = Lists.newArrayList();
 
                 starting();
 

--- a/src/test/java/io/apiman/cli/gatewayapi/command/generate/GenerateHeadlessTest.java
+++ b/src/test/java/io/apiman/cli/gatewayapi/command/generate/GenerateHeadlessTest.java
@@ -64,10 +64,10 @@ public class GenerateHeadlessTest extends BaseTest {
     public void testGenerateConfig_withRealFileOutput()  throws Exception {
         String outputPath = "/tmp/plugin-and-builtin-policies_headless.json";
 
-        command.setDeclarationFile(getResourceAsPath("/gateway/generateHeadless/plugin-and-builtin-policies.yml"));
+        command.setDeclarationFiles(getResourceAsPathList("/gateway/generateHeadless/plugin-and-builtin-policies.yml"));
         command.outputFiles.add(Paths.get(outputPath));
         // Run
-        command.applyDeclaration();
+        command.applyDeclarations();
         // Verify file exists
         isTrue(Files.exists(Paths.get(outputPath)));
         // Read the output file back in, and compare with expected result
@@ -77,10 +77,10 @@ public class GenerateHeadlessTest extends BaseTest {
 
     @Test
     public void testGenerateConfig_writeToDirectory() throws Exception {
-        command.setDeclarationFile(getResourceAsPath("/gateway/generateHeadless/plugin-and-builtin-policies.yml"));
+        command.setDeclarationFiles(getResourceAsPathList("/gateway/generateHeadless/plugin-and-builtin-policies.yml"));
         command.outputFiles.add(Paths.get("/tmp"));
         // Run
-        command.applyDeclaration();
+        command.applyDeclarations();
         // Verify file exists
         isTrue(Files.exists(Paths.get("/tmp/test-gw.json"))); // Note generated name
         // Read the output file back in, and compare with expected result
@@ -92,10 +92,10 @@ public class GenerateHeadlessTest extends BaseTest {
     public void testGenerateConfig_withExplicitOutputFilename() throws Exception {
         command.setJsonWriter(mJsonWriter);
 
-        command.setDeclarationFile(getResourceAsPath("/gateway/generateHeadless/plugin-and-builtin-policies.yml"));
+        command.setDeclarationFiles(getResourceAsPathList("/gateway/generateHeadless/plugin-and-builtin-policies.yml"));
         command.outputFiles.add(Paths.get("/tmp/someOutputFile.json")); // Doesn't matter, we're stubbing this.
         // Run
-        command.applyDeclaration();
+        command.applyDeclarations();
         // Verify
         Api expectedApi = expectJson("/gateway/plugin-and-builtin-policies-expectation.json", Api.class);
         // We expect the above API to be written
@@ -107,10 +107,10 @@ public class GenerateHeadlessTest extends BaseTest {
     public void testGenerateConfig_withTransformedName() throws Exception {
         command.setJsonWriter(mJsonWriter);
 
-        command.setDeclarationFile(getResourceAsPath("/gateway/generateHeadless/transform-name.yml"));
+        command.setDeclarationFiles(getResourceAsPathList("/gateway/generateHeadless/transform-name.yml"));
         command.outputFiles.add(Paths.get("/tmp"));
         // Run
-        command.applyDeclaration();
+        command.applyDeclarations();
         // Verify
         HeadlessConfigBean expected = expectJson("/gateway/generateHeadless/transform-name.json", HeadlessConfigBean.class);
         // Space-type characters and forward slashes should be substituted with -
@@ -121,11 +121,11 @@ public class GenerateHeadlessTest extends BaseTest {
     public void testGenerateConfig_withMultipleGatewayConfigs_ExplicitName() throws Exception {
         command.setJsonWriter(mJsonWriter);
 
-        command.setDeclarationFile(getResourceAsPath("/gateway/generateHeadless/plugin-and-builtin-policies_multiple-gateways.yml"));
+        command.setDeclarationFiles(getResourceAsPathList("/gateway/generateHeadless/plugin-and-builtin-policies_multiple-gateways.yml"));
         command.outputFiles.add(Paths.get("/tmp/someOutputFile.json")); // Doesn't matter, we're stubbing this.
         command.outputFiles.add(Paths.get("/tmp/someOutputFile2.json")); // Doesn't matter, we're stubbing this.
         // Run
-        command.applyDeclaration();
+        command.applyDeclarations();
         // Verify it matches our reference configs.
         HeadlessConfigBean expectedConfig1 = expectJson("/gateway/generateHeadless/expected-multiple-gateways.json", HeadlessConfigBean.class);
         HeadlessConfigBean expectedConfig2 = expectJson("/gateway/generateHeadless/expected-multiple-gateways-2.json", HeadlessConfigBean.class);
@@ -138,10 +138,10 @@ public class GenerateHeadlessTest extends BaseTest {
     public void testGenerateConfig_withMultipleGatewayConfigs_GeneratedName() throws Exception {
         command.setJsonWriter(mJsonWriter);
 
-        command.setDeclarationFile(getResourceAsPath("/gateway/generateHeadless/plugin-and-builtin-policies_multiple-gateways.yml"));
+        command.setDeclarationFiles(getResourceAsPathList("/gateway/generateHeadless/plugin-and-builtin-policies_multiple-gateways.yml"));
         command.outputFiles.add(Paths.get("/tmp")); // Directory.
         // Run
-        command.applyDeclaration();
+        command.applyDeclarations();
         // Verify it matches our reference configs.
         HeadlessConfigBean expectedConfig1 = expectJson("/gateway/generateHeadless/expected-multiple-gateways.json", HeadlessConfigBean.class);
         HeadlessConfigBean expectedConfig2 = expectJson("/gateway/generateHeadless/expected-multiple-gateways-2.json", HeadlessConfigBean.class);

--- a/src/test/java/io/apiman/cli/managerapi/command/declarative/command/ManagerDeclarativeTest.java
+++ b/src/test/java/io/apiman/cli/managerapi/command/declarative/command/ManagerDeclarativeTest.java
@@ -64,8 +64,8 @@ public class ManagerDeclarativeTest extends BaseTest {
      */
     @Test
     public void testApplyDeclaration_JustPlugins() throws Exception {
-        command.setDeclarationFile(Paths.get(ManagerDeclarativeTest.class.getResource("/simple-plugin.yml").toURI()));
-        command.applyDeclaration();
+        command.setDeclarationFiles(getResourceAsPathList("/simple-plugin.yml"));
+        command.applyDeclarations();
     }
 
     /**
@@ -75,8 +75,8 @@ public class ManagerDeclarativeTest extends BaseTest {
      */
     @Test
     public void testApplyDeclaration_Full() throws Exception {
-        command.setDeclarationFile(Paths.get(ManagerDeclarativeTest.class.getResource("/simple-no-plugin.yml").toURI()));
-        command.applyDeclaration();
+        command.setDeclarationFiles(getResourceAsPathList("/simple-no-plugin.yml"));
+        command.applyDeclarations();
     }
 
     /**
@@ -96,13 +96,13 @@ public class ManagerDeclarativeTest extends BaseTest {
                 "gw.endpoint=http://example.com"
         );
 
-        command.setDeclarationFile(Paths.get(ManagerDeclarativeTest.class.getResource("/simple-placeholders.yml").toURI()));
+        command.setDeclarationFiles(getResourceAsPathList("/simple-placeholders.yml"));
         command.setProperties(inlineProperties);
         command.setPropertiesFiles(Lists.newArrayList(
                 Paths.get(ManagerDeclarativeTest.class.getResource("/placeholder-test.properties").toURI()),
                 Paths.get(ManagerDeclarativeTest.class.getResource("/placeholder-test.xml").toURI())
         ));
-        command.applyDeclaration();
+        command.applyDeclarations();
     }
 
     /**
@@ -113,7 +113,7 @@ public class ManagerDeclarativeTest extends BaseTest {
      */
     @Test
     public void testApplyDeclaration_MultipleVersions() throws Exception {
-        command.setDeclarationFile(Paths.get(ManagerDeclarativeTest.class.getResource("/multiple-versions.yml").toURI()));
-        command.applyDeclaration();
+        command.setDeclarationFiles(getResourceAsPathList("/multiple-versions.yml"));
+        command.applyDeclarations();
     }
 }


### PR DESCRIPTION
Both manager and gateway commands support repetition of the `--declarationFile` argument.

This means in the following cases:

* declarative gateway
* declarative manager
* generate headless gateway configuration

...you can do things like:

```
./apiman manager apply --declarationFile=file1.yml --declarationFile=file2.yml
```

...and the contents will be merged in the order provided.

Supersedes #33 