### PR TITLE
Specify policies and configuration common to all APIs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
-- ...
+- Adds the ability to specify policies and configuration that should be present on every API.
 
 ## [0.3.2] - 2020-02-17
 ### Changed

--- a/README.md
+++ b/README.md
@@ -332,11 +332,9 @@ If you just want to run _apiman-cli_, use the _apiman_ or _apiman.bat_ (Windows)
 
 If you want to compile the JAR yourself, use:
 
-    ./gradlew clean build
-    
-Note: for distribution, _apiman-cli_ is built as a 'fat JAR' (aka 'shadow JAR'). To do this yourself, run:
-
     ./gradlew clean shadowJar
+    
+> Note: for distribution, _apiman-cli_ is built as a 'fat JAR' (aka 'shadow JAR').
 
 ...and look under the `build/libs` directory.
 

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ ext {
     version_retrofit = '1.9.0'
     version_jackson_yaml = '2.10.2'
     version_modelmapper = '2.3.6'
+    version_commons_beanutils = '1.9.3'
     version_commons_lang = '3.4'
     version_guice = '4.0'
     version_apiman = '1.4.3.Final'
@@ -60,6 +61,7 @@ dependencies {
     compile "com.squareup.retrofit:converter-jackson:$version_retrofit"
     compile "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$version_jackson_yaml"
     compile "org.modelmapper:modelmapper:$version_modelmapper"
+    compile "commons-beanutils:commons-beanutils:$version_commons_beanutils"
     compile "org.apache.commons:commons-lang3:$version_commons_lang"
     compile "com.google.inject:guice:$version_guice"
     

--- a/examples/declarative/common-api-config.yml
+++ b/examples/declarative/common-api-config.yml
@@ -1,0 +1,54 @@
+# Common configuration and policies across all APIs.
+---
+system:
+  gateways:
+    - name: "test-gw"
+      description: "Test Gateway"
+      type: "REST"
+      config:
+        endpoint: "http://localhost:8080/apiman-gateway-api"
+        username: "apimanager"
+        password: "apiman123!"
+  plugins:
+    - groupId: "io.apiman.plugins"
+      artifactId: "apiman-plugins-test-policy"
+      version: "1.4.3.Final"
+    - name: "log-policy"
+      groupId: "io.apiman.plugins"
+      artifactId: "apiman-plugins-log-policy"
+      version: "1.4.3.Final"
+shared:
+  policies:
+    - $id: "alwaysFirstPolicy"
+      plugin: "log-policy"
+      name: "log-headers-policy"
+      config:
+        direction: "both"
+    - $id: "alwaysLastPolicy"
+      name: "CachingPolicy"
+      config:
+        ttl: 60
+org:
+  name: "test"
+  description: "Test organisation"
+  # Configuration and policies in the common org section are applied to each API.
+  common:
+    # Common configuration is overridden by API specific values.
+    config:
+      endpointType: "rest"
+      public: true
+      gateway: "test-gw"
+    # Common policies are injected at either the start or the end of the policy chain for each API.
+    policies:
+      first:
+        - "alwaysFirstPolicy"
+      last:
+        - "alwaysLastPolicy"
+  apis:
+    - name: "example"
+      description: "Example API"
+      version: "1.0"
+      published: true
+      config:
+        endpoint: "http://example.com"
+      policies: []

--- a/src/main/java/io/apiman/cli/command/api/model/ApiConfig.java
+++ b/src/main/java/io/apiman/cli/command/api/model/ApiConfig.java
@@ -40,8 +40,11 @@ public class ApiConfig {
     @JsonProperty
     private EndpointProperties endpointProperties;
 
+    /**
+     * Deliberate use of object instead of primitive, to allow nullity check.
+     */
     @JsonProperty("publicAPI")
-    private boolean publicApi;
+    private Boolean publicApi;
 
     @JsonProperty
     private List<ApiGateway> gateways;
@@ -84,11 +87,11 @@ public class ApiConfig {
         this.gateways = gateways;
     }
 
-    public void setPublicApi(boolean publicApi) {
+    public void setPublicApi(Boolean publicApi) {
         this.publicApi = publicApi;
     }
 
-    public boolean isPublicApi() {
+    public Boolean getPublicApi() {
         return publicApi;
     }
 

--- a/src/main/java/io/apiman/cli/command/declarative/DeclarativeUtil.java
+++ b/src/main/java/io/apiman/cli/command/declarative/DeclarativeUtil.java
@@ -20,7 +20,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Maps;
 import com.google.common.io.CharStreams;
 import io.apiman.cli.command.declarative.model.BaseDeclaration;
+import io.apiman.cli.command.declarative.model.DeclarativeOrgCommon;
+import io.apiman.cli.command.declarative.model.DeclarativePolicy;
 import io.apiman.cli.command.declarative.model.SharedItems;
+import io.apiman.cli.exception.CommandException;
 import io.apiman.cli.exception.DeclarativeException;
 import io.apiman.cli.util.BeanUtil;
 import org.apache.logging.log4j.LogManager;
@@ -31,9 +34,16 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 
+import static com.google.common.collect.Lists.newArrayList;
+import static java.util.Collections.emptyList;
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
 import static java.util.Optional.ofNullable;
 
 /**
@@ -43,6 +53,36 @@ import static java.util.Optional.ofNullable;
  */
 public class DeclarativeUtil {
     private static final Logger LOGGER = LogManager.getLogger(DeclarativeUtil.class);
+
+    /**
+     * Parse the provided properties list and combine with those in the properties files.
+     *
+     * @param properties      the properties in 'key=value' format
+     * @param propertiesFiles files in Java Properties format
+     * @return the combined properties
+     */
+    public static Map<String, String> parseProperties(List<String> properties, List<Path> propertiesFiles) {
+        final Map<String, String> parsedProperties = BeanUtil.parseReplacements(properties);
+
+        // check for properties file
+        ofNullable(propertiesFiles).ifPresent(pf -> pf.forEach(propertiesFile -> {
+            LOGGER.trace("Loading properties file: {}", propertiesFile);
+
+            final Properties fileProperties = new Properties();
+            try (final InputStream propertiesIn = Files.newInputStream(propertiesFile, StandardOpenOption.READ)) {
+                if (propertiesFile.toAbsolutePath().toString().toLowerCase().endsWith(".xml")) {
+                    fileProperties.loadFromXML(propertiesIn);
+                } else {
+                    fileProperties.load(propertiesIn);
+                }
+            } catch (IOException e) {
+                throw new CommandException(String.format("Error loading properties file: %s", propertiesFile), e);
+            }
+
+            fileProperties.forEach((key, value) -> parsedProperties.put((String) key, (String) value));
+        }));
+        return parsedProperties;
+    }
 
     /**
      * Load the Declaration from the given Path, using the mapper provided.
@@ -73,6 +113,19 @@ public class DeclarativeUtil {
                 declaration = loadDeclaration(mapper, fileContents, mutableProperties);
             }
 
+            if (nonNull(declaration.getOrg())) {
+                // ensure APIs and Policies are non-null
+                if (isNull(declaration.getOrg().getApis())) {
+                    declaration.getOrg().setApis(newArrayList());
+                }
+                declaration.getOrg().getApis().forEach(api -> {
+                    if (isNull(api.getPolicies())) {
+                        api.setPolicies(newArrayList());
+                    }
+                });
+                applyCommonOrgElements(declaration);
+            }
+
             return declaration;
 
         } catch (IOException e) {
@@ -95,5 +148,42 @@ public class DeclarativeUtil {
         final String resolved = BeanUtil.resolvePlaceholders(unresolved, properties);
         LOGGER.trace("Declaration file after resolving {} placeholders: {}", properties.size(), resolved);
         return mapper.readValue(resolved, BaseDeclaration.class);
+    }
+
+    /**
+     * Applies common elements such as configuration and policies to each API in the organisation.
+     *
+     * @param declaration the API declaration to update
+     */
+    private static void applyCommonOrgElements(BaseDeclaration declaration) {
+        ofNullable(declaration.getOrg()).flatMap(org -> ofNullable(org.getCommon())).ifPresent(common -> {
+            applyCommonConfig(declaration, common);
+            applyCommonPolicies(declaration, common);
+        });
+    }
+
+    private static void applyCommonConfig(BaseDeclaration declaration, DeclarativeOrgCommon common) {
+        ofNullable(common.getConfig()).ifPresent(commonConfig -> {
+            LOGGER.trace("Injecting common configuration into all APIs");
+            declaration.getOrg().getApis().forEach(api -> {
+                BeanUtil.shallowCopyToNonNullFields(commonConfig, api.getConfig());
+            });
+        });
+    }
+
+    private static void applyCommonPolicies(BaseDeclaration declaration, DeclarativeOrgCommon common) {
+        ofNullable(common.getPolicies()).ifPresent(commonPolicies -> {
+            final List<DeclarativePolicy> first = ofNullable(commonPolicies.getFirst()).orElse(emptyList());
+            final List<DeclarativePolicy> last = ofNullable(commonPolicies.getLast()).orElse(emptyList());
+
+            if (!first.isEmpty() || !last.isEmpty()) {
+                LOGGER.trace("Injecting common policies into all APIs [{} first, {} last]", first.size(), last.size());
+                declaration.getOrg().getApis().forEach(api -> {
+                    final List<DeclarativePolicy> policies = api.getPolicies();
+                    policies.addAll(0, first);
+                    policies.addAll(last);
+                });
+            }
+        });
     }
 }

--- a/src/main/java/io/apiman/cli/command/declarative/model/DeclarativeApiConfig.java
+++ b/src/main/java/io/apiman/cli/command/declarative/model/DeclarativeApiConfig.java
@@ -32,8 +32,11 @@ public class DeclarativeApiConfig extends ApiConfig {
     @JsonProperty("gateway")
     private String gateway;
 
+    /**
+     * Deliberate use of object instead of primitive, to allow nullity check.
+     */
     @JsonProperty("public")
-    private boolean makePublic;
+    private Boolean makePublic;
 
     @JsonProperty("security")
     private DeclarativeEndpointSecurity security;
@@ -46,11 +49,11 @@ public class DeclarativeApiConfig extends ApiConfig {
         this.gateway = gateway;
     }
 
-    public void setMakePublic(boolean makePublic) {
+    public void setMakePublic(Boolean makePublic) {
         this.makePublic = makePublic;
     }
 
-    public boolean isMakePublic() {
+    public Boolean getMakePublic() {
         return makePublic;
     }
 

--- a/src/main/java/io/apiman/cli/command/declarative/model/DeclarativeOrgCommon.java
+++ b/src/main/java/io/apiman/cli/command/declarative/model/DeclarativeOrgCommon.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Pete Cornish
+ * Copyright 2020 Pete Cornish
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,36 +19,26 @@ package io.apiman.cli.command.declarative.model;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import io.apiman.cli.command.org.model.Org;
-
-import java.util.List;
 
 /**
- * Declarative organisation representation.
+ * Represents elements present in every API.
  *
  * @author Pete Cornish {@literal <outofcoffee@gmail.com>}
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
-public class DeclarativeOrg extends Org {
-    /**
-     * Common elements for every API.
-     */
+public class DeclarativeOrgCommon {
     @JsonProperty
-    private DeclarativeOrgCommon common;
+    private DeclarativeApiConfig config;
 
     @JsonProperty
-    private List<DeclarativeApi> apis;
+    private DeclarativeOrgCommonPolicies policies;
 
-    public DeclarativeOrgCommon getCommon() {
-        return common;
+    public DeclarativeApiConfig getConfig() {
+        return config;
     }
 
-    public List<DeclarativeApi> getApis() {
-        return apis;
-    }
-
-    public void setApis(List<DeclarativeApi> apis) {
-        this.apis = apis;
+    public DeclarativeOrgCommonPolicies getPolicies() {
+        return policies;
     }
 }

--- a/src/main/java/io/apiman/cli/command/declarative/model/DeclarativeOrgCommonPolicies.java
+++ b/src/main/java/io/apiman/cli/command/declarative/model/DeclarativeOrgCommonPolicies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Pete Cornish
+ * Copyright 2020 Pete Cornish
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,36 +19,34 @@ package io.apiman.cli.command.declarative.model;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import io.apiman.cli.command.org.model.Org;
 
 import java.util.List;
 
 /**
- * Declarative organisation representation.
+ * Represents policies present in every chain.
  *
  * @author Pete Cornish {@literal <outofcoffee@gmail.com>}
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
-public class DeclarativeOrg extends Org {
+public class DeclarativeOrgCommonPolicies {
     /**
-     * Common elements for every API.
+     * Policies added to the beginning of every chain.
      */
     @JsonProperty
-    private DeclarativeOrgCommon common;
+    private List<DeclarativePolicy> first;
 
+    /**
+     * Policies added to the end of every chain.
+     */
     @JsonProperty
-    private List<DeclarativeApi> apis;
+    private List<DeclarativePolicy> last;
 
-    public DeclarativeOrgCommon getCommon() {
-        return common;
+    public List<DeclarativePolicy> getFirst() {
+        return first;
     }
 
-    public List<DeclarativeApi> getApis() {
-        return apis;
-    }
-
-    public void setApis(List<DeclarativeApi> apis) {
-        this.apis = apis;
+    public List<DeclarativePolicy> getLast() {
+        return last;
     }
 }

--- a/src/main/java/io/apiman/cli/gatewayapi/model/GatewayApiDataModel.java
+++ b/src/main/java/io/apiman/cli/gatewayapi/model/GatewayApiDataModel.java
@@ -168,7 +168,7 @@ public class GatewayApiDataModel {
 
         DeclarativeApiConfig apiConfig = modelApi.getConfig();
         api.setEndpoint(apiConfig.getEndpoint());
-        api.setPublicAPI(apiConfig.isMakePublic()); // Why is this different to publicApi?
+        api.setPublicAPI(apiConfig.getMakePublic()); // Why is this different to publicApi?
         api.setEndpointType(apiConfig.getEndpointType());
 
         ofNullable(apiConfig.getSecurity()).ifPresent(declarativeEndpointProperties -> {

--- a/src/main/java/io/apiman/cli/util/MappingUtil.java
+++ b/src/main/java/io/apiman/cli/util/MappingUtil.java
@@ -178,7 +178,7 @@ public final class MappingUtil {
         // PostConverter for ApiConfig -> ServiceConfig
         mapper.createTypeMap(ApiConfig.class, ServiceConfig.class).setPostConverter(context -> {
             final ServiceConfig serviceConfig = context.getDestination();
-            serviceConfig.setPublicService(context.getSource().isPublicApi());
+            serviceConfig.setPublicService(context.getSource().getPublicApi());
             return serviceConfig;
         });
 
@@ -194,7 +194,7 @@ public final class MappingUtil {
             final DeclarativeApiConfig declarativeApiConfig = context.getSource();
 
             final ApiConfig apiConfig = context.getDestination();
-            apiConfig.setPublicApi(declarativeApiConfig.isMakePublic());
+            apiConfig.setPublicApi(declarativeApiConfig.getMakePublic());
             apiConfig.setGateways(Lists.newArrayList(new ApiGateway(declarativeApiConfig.getGateway())));
 
             return apiConfig;

--- a/src/test/java/io/apiman/cli/command/GatewayDeclarativeTest.java
+++ b/src/test/java/io/apiman/cli/command/GatewayDeclarativeTest.java
@@ -108,4 +108,19 @@ public class GatewayDeclarativeTest extends BaseTest {
         verify(mGatewayApi).publishApi(Mockito.argThat(api -> EqualsBuilder.reflectionEquals(api, expected1)));
         verify(mGatewayApi).publishApi(Mockito.argThat(api -> EqualsBuilder.reflectionEquals(api, expected2)));
     }
+
+    /**
+     * Common API configuration and policies that should be applied to all APIs in the organisation.
+     *
+     * @throws Exception any exception
+     */
+    @Test
+    public void testApplyDeclaration_CommonApiConfig() throws Exception {
+        command.setDeclarationFiles(getResourceAsPathList("/common-api-config.yml"));
+        Api expected = expectJson("/gateway/common-api-config-expectation.json", Api.class);
+        // Run
+        command.applyDeclarations();
+        // Verify
+        verify(mGatewayApi).publishApi(Mockito.argThat(api -> EqualsBuilder.reflectionEquals(api, expected)));
+    }
 }

--- a/src/test/java/io/apiman/cli/command/GatewayDeclarativeTest.java
+++ b/src/test/java/io/apiman/cli/command/GatewayDeclarativeTest.java
@@ -16,7 +16,7 @@
 
 package io.apiman.cli.command;
 
-import io.apiman.cli.common.BaseTest;
+import io.apiman.cli.common.BaseIntegrationTest;
 import io.apiman.cli.common.IntegrationTest;
 import io.apiman.cli.gatewayapi.GatewayApi;
 import io.apiman.cli.gatewayapi.command.factory.GatewayApiFactory;
@@ -37,7 +37,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @Category(IntegrationTest.class)
-public class GatewayDeclarativeTest extends BaseTest {
+public class GatewayDeclarativeTest extends BaseIntegrationTest {
     private static final boolean LOG_DEBUG = true;
 
     private GatewayApplyCommand command;

--- a/src/test/java/io/apiman/cli/common/BaseIntegrationTest.java
+++ b/src/test/java/io/apiman/cli/common/BaseIntegrationTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2016 Pete Cornish
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apiman.cli.common;
+
+import com.google.common.base.Strings;
+import com.google.common.io.BaseEncoding;
+import com.jayway.restassured.RestAssured;
+import io.apiman.cli.Cli;
+import io.apiman.cli.util.AuthUtil;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+
+import java.net.HttpURLConnection;
+
+import static io.apiman.cli.util.Functions.not;
+import static java.util.Optional.ofNullable;
+
+/**
+ * This base class waits for an instance of apiman.
+ *
+ * @author Pete Cornish {@literal <outofcoffee@gmail.com>}
+ */
+public abstract class BaseIntegrationTest extends BaseTest {
+    /**
+     * Management API username.
+     */
+    protected static final String APIMAN_USERNAME = "admin";
+
+    /**
+     * Management API password.
+     */
+    protected static final String APIMAN_PASSWORD = "admin123!";
+
+    /**
+     * Encoded credentials for Basic auth.
+     */
+    protected static final String BASIC_AUTH_VALUE = "Basic " + BaseEncoding.base64().encode(
+            (APIMAN_USERNAME + ":" + APIMAN_PASSWORD).getBytes());
+
+    /**
+     * Wait for apiman to be available.
+     * Returns a 200 on 'http://docker.local:8080/apiman/system/status' when ready.
+     */
+    @ClassRule
+    public static WaitForHttp apiman = new WaitForHttp(getApimanHost(), getApimanPort(), "/apiman/system/status")
+            .withStatusCode(HttpURLConnection.HTTP_OK)
+            .withBasicCredentials(AuthUtil.DEFAULT_SERVER_USERNAME, AuthUtil.DEFAULT_SERVER_PASSWORD);
+
+    private static String getApimanHost() {
+        return ofNullable(System.getProperty("apiman.host"))
+                .filter(not(Strings::isNullOrEmpty))
+                .orElse("localhost");
+    }
+
+    private static int getApimanPort() {
+        return ofNullable(System.getProperty("apiman.port"))
+                .filter(not(Strings::isNullOrEmpty))
+                .map(Integer::parseInt)
+                .orElse(8080);
+    }
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        RestAssured.baseURI = getApimanUrl();
+    }
+
+    protected static String getApimanUrl() {
+        return apiman.getAddress() + "/apiman";
+    }
+
+    /**
+     * Create an org with the given name.
+     *
+     * @param orgName the org name
+     */
+    protected void createOrg(String orgName) {
+        Cli.main("manager",
+                "org", "create",
+                "--debug",
+                "--server", getApimanUrl(),
+                "--serverUsername", AuthUtil.DEFAULT_SERVER_USERNAME,
+                "--serverPassword", AuthUtil.DEFAULT_SERVER_PASSWORD,
+                "--name", orgName,
+                "--description", "example");
+    }
+}

--- a/src/test/java/io/apiman/cli/common/BaseTest.java
+++ b/src/test/java/io/apiman/cli/common/BaseTest.java
@@ -16,18 +16,10 @@
 
 package io.apiman.cli.common;
 
-import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
-import com.jayway.restassured.RestAssured;
-import com.google.common.io.BaseEncoding;
-import io.apiman.cli.Cli;
-import io.apiman.cli.util.AuthUtil;
 import io.apiman.cli.util.MappingUtil;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
 
 import java.io.IOException;
-import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -36,78 +28,12 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 
-import static io.apiman.cli.util.Functions.not;
-import static java.util.Optional.ofNullable;
-
 /**
- * This base class waits for an instance of apiman.
+ * Convenience methods for tests.
  *
  * @author Pete Cornish {@literal <outofcoffee@gmail.com>}
  */
-public class BaseTest {
-    /**
-     * Management API username.
-     */
-    protected static final String APIMAN_USERNAME = "admin";
-
-    /**
-     * Management API password.
-     */
-    protected static final String APIMAN_PASSWORD = "admin123!";
-
-    /**
-     * Encoded credentials for Basic auth.
-     */
-    protected static final String BASIC_AUTH_VALUE = "Basic " + BaseEncoding.base64().encode(
-            (APIMAN_USERNAME + ":" + APIMAN_PASSWORD).getBytes());
-
-    /**
-     * Wait for apiman to be available.
-     * Returns a 200 on 'http://docker.local:8080/apiman/system/status' when ready.
-     */
-    @ClassRule
-    public static WaitForHttp apiman = new WaitForHttp(getApimanHost(), getApimanPort(), "/apiman/system/status")
-            .withStatusCode(HttpURLConnection.HTTP_OK)
-            .withBasicCredentials(AuthUtil.DEFAULT_SERVER_USERNAME, AuthUtil.DEFAULT_SERVER_PASSWORD);
-
-    private static String getApimanHost() {
-        return ofNullable(System.getProperty("apiman.host"))
-                .filter(not(Strings::isNullOrEmpty))
-                .orElse("localhost");
-    }
-
-    private static int getApimanPort() {
-        return ofNullable(System.getProperty("apiman.port"))
-                .filter(not(Strings::isNullOrEmpty))
-                .map(Integer::parseInt)
-                .orElse(8080);
-    }
-
-    @BeforeClass
-    public static void beforeClass() throws Exception {
-        RestAssured.baseURI = getApimanUrl();
-    }
-
-    protected static String getApimanUrl() {
-        return apiman.getAddress() + "/apiman";
-    }
-
-    /**
-     * Create an org with the given name.
-     *
-     * @param orgName the org name
-     */
-    protected void createOrg(String orgName) {
-        Cli.main("manager",
-                "org", "create",
-                "--debug",
-                "--server", getApimanUrl(),
-                "--serverUsername", AuthUtil.DEFAULT_SERVER_USERNAME,
-                "--serverPassword", AuthUtil.DEFAULT_SERVER_PASSWORD,
-                "--name", orgName,
-                "--description", "example");
-    }
-
+public abstract class BaseTest {
     protected <T> T expectJson(String resource, Class<T> klazz) throws URISyntaxException, MalformedURLException {
         return MappingUtil.readJsonValue(getResourceAsURI(resource).toURL(), klazz);
     }

--- a/src/test/java/io/apiman/cli/managerapi/command/api/ApiTest.java
+++ b/src/test/java/io/apiman/cli/managerapi/command/api/ApiTest.java
@@ -17,7 +17,7 @@
 package io.apiman.cli.managerapi.command.api;
 
 import io.apiman.cli.Cli;
-import io.apiman.cli.common.BaseTest;
+import io.apiman.cli.common.BaseIntegrationTest;
 import io.apiman.cli.common.IntegrationTest;
 import io.apiman.cli.util.AuthUtil;
 import org.junit.FixMethodOrder;
@@ -30,7 +30,7 @@ import org.junit.runners.MethodSorters;
  */
 @Category(IntegrationTest.class)
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
-public class ApiTest extends BaseTest {
+public class ApiTest extends BaseIntegrationTest {
     private static final String ORG_NAME = "apitest";
 
     @Test

--- a/src/test/java/io/apiman/cli/managerapi/command/declarative/command/ManagerDeclarativeTest.java
+++ b/src/test/java/io/apiman/cli/managerapi/command/declarative/command/ManagerDeclarativeTest.java
@@ -17,7 +17,7 @@
 package io.apiman.cli.managerapi.command.declarative.command;
 
 import com.google.common.collect.Lists;
-import io.apiman.cli.common.BaseTest;
+import io.apiman.cli.common.BaseIntegrationTest;
 import io.apiman.cli.common.IntegrationTest;
 import io.apiman.cli.managerapi.command.common.model.ManagementApiVersion;
 import io.apiman.cli.managerapi.declarative.command.ManagerApplyCommand;
@@ -37,7 +37,7 @@ import java.util.List;
  * @author Pete Cornish {@literal <outofcoffee@gmail.com>}
  */
 @Category(IntegrationTest.class)
-public class ManagerDeclarativeTest extends BaseTest {
+public class ManagerDeclarativeTest extends BaseIntegrationTest {
     private static final boolean LOG_DEBUG = true;
 
     @Inject

--- a/src/test/java/io/apiman/cli/managerapi/command/gateway/GatewayTest.java
+++ b/src/test/java/io/apiman/cli/managerapi/command/gateway/GatewayTest.java
@@ -17,7 +17,7 @@
 package io.apiman.cli.managerapi.command.gateway;
 
 import io.apiman.cli.Cli;
-import io.apiman.cli.common.BaseTest;
+import io.apiman.cli.common.BaseIntegrationTest;
 import io.apiman.cli.common.IntegrationTest;
 import io.apiman.cli.util.AuthUtil;
 
@@ -31,7 +31,7 @@ import org.junit.runners.MethodSorters;
  */
 @Category(IntegrationTest.class)
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
-public class GatewayTest extends BaseTest {
+public class GatewayTest extends BaseIntegrationTest {
 
     @Test
     public void test1_test() {

--- a/src/test/java/io/apiman/cli/managerapi/command/org/OrgTest.java
+++ b/src/test/java/io/apiman/cli/managerapi/command/org/OrgTest.java
@@ -17,7 +17,7 @@
 package io.apiman.cli.managerapi.command.org;
 
 import io.apiman.cli.Cli;
-import io.apiman.cli.common.BaseTest;
+import io.apiman.cli.common.BaseIntegrationTest;
 import io.apiman.cli.common.IntegrationTest;
 import io.apiman.cli.util.AuthUtil;
 
@@ -31,7 +31,7 @@ import org.junit.runners.MethodSorters;
  */
 @Category(IntegrationTest.class)
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
-public class OrgTest extends BaseTest {
+public class OrgTest extends BaseIntegrationTest {
 
     @Test
     public void test1_create() {

--- a/src/test/java/io/apiman/cli/managerapi/command/plugin/PluginTest.java
+++ b/src/test/java/io/apiman/cli/managerapi/command/plugin/PluginTest.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.jayway.restassured.response.Response;
 import io.apiman.cli.Cli;
 import io.apiman.cli.command.plugin.model.Plugin;
-import io.apiman.cli.common.BaseTest;
+import io.apiman.cli.common.BaseIntegrationTest;
 import io.apiman.cli.common.IntegrationTest;
 import io.apiman.cli.util.AuthUtil;
 import io.apiman.cli.util.MappingUtil;
@@ -44,7 +44,7 @@ import static org.junit.Assert.assertTrue;
  */
 @Category(IntegrationTest.class)
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
-public class PluginTest extends BaseTest {
+public class PluginTest extends BaseIntegrationTest {
     private static final String PLUGIN_ARTIFACTID = "apiman-plugins-transformation-policy";
     private static final String PLUGIN_GROUPID = "io.apiman.plugins";
     private static final String PLUGIN_VERSION = "1.4.3.Final";

--- a/src/test/resources/common-api-config.yml
+++ b/src/test/resources/common-api-config.yml
@@ -1,0 +1,54 @@
+# Common configuration and policies across all APIs.
+---
+system:
+  gateways:
+    - name: "test-gw"
+      description: "Test Gateway"
+      type: "REST"
+      config:
+        endpoint: "http://localhost:8080/apiman-gateway-api"
+        username: "apimanager"
+        password: "apiman123!"
+  plugins:
+    - groupId: "io.apiman.plugins"
+      artifactId: "apiman-plugins-test-policy"
+      version: "1.4.3.Final"
+    - name: "log-policy"
+      groupId: "io.apiman.plugins"
+      artifactId: "apiman-plugins-log-policy"
+      version: "1.4.3.Final"
+shared:
+  policies:
+    - $id: "alwaysFirstPolicy"
+      plugin: "log-policy"
+      name: "log-headers-policy"
+      config:
+        direction: "both"
+    - $id: "alwaysLastPolicy"
+      name: "CachingPolicy"
+      config:
+        ttl: 60
+org:
+  name: "test"
+  description: "Test organisation"
+  # Configuration and policies in the common org section are applied to each API.
+  common:
+    # Common configuration is overridden by API specific values.
+    config:
+      endpointType: "rest"
+      public: true
+      gateway: "test-gw"
+    # Common policies are injected at either the start or the end of the policy chain for each API.
+    policies:
+      first:
+        - "alwaysFirstPolicy"
+      last:
+        - "alwaysLastPolicy"
+  apis:
+    - name: "common-api-config"
+      description: "Example API"
+      version: "1.0"
+      published: true
+      config:
+        endpoint: "http://example.com"
+      policies: []

--- a/src/test/resources/gateway/common-api-config-expectation.json
+++ b/src/test/resources/gateway/common-api-config-expectation.json
@@ -1,0 +1,19 @@
+{
+  "publicAPI" : true,
+  "organizationId" : "test",
+  "apiId" : "common-api-config",
+  "version" : "1.0",
+  "endpoint" : "http://example.com",
+  "endpointType" : "rest",
+  "endpointContentType" : null,
+  "endpointProperties" : { },
+  "parsePayload" : false,
+  "apiPolicies" : [ {
+    "policyJsonConfig" : "{\n  \"direction\" : \"both\"\n}",
+    "policyImpl" : "plugin:io.apiman.plugins:apiman-plugins-log-policy:1.4.3.Final:war/io.apiman.plugins.log_policy.LogHeadersPolicy"
+  }, {
+    "policyJsonConfig" : "{\n  \"ttl\" : 60\n}",
+    "policyImpl" : "class:io.apiman.gateway.engine.policies.CachingPolicy"
+  } ],
+  "maxPayloadBufferSize" : 0
+}


### PR DESCRIPTION
## What does this do?

Adds the ability to specify policies and configuration that should be present on every API. This enables less boilerplate and better reuse in API declaration files.

## Implementation notes

* The `common` block is a new addition to the `org` block. It's optional, so files without it are backwards compatible.
* The reliable copying of bean properties all the way up the inheritance hierarchy is non-trivial, so I elected to use `commons-beanutils` - I couldn't find a way to make ModelMapper do it without a bunch of bespoke reflection code

## Example

Here's the new block inside `org`:

```
org:
  # Configuration and policies in the common org section are applied to each API.
  common:
    # Common configuration is overridden by API specific values.
    config:
      endpointType: "rest"
      public: true
      gateway: "test-gw"
    # Common policies are injected at either the start or the end of the policy chain for each API.
    policies:
      first:
        - "alwaysFirstPolicy"
      last:
        - "alwaysLastPolicy"
  # APIs inherit the above
  apis: [ ... ]